### PR TITLE
Fixed Issue with Node Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Install Dependencies
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
Fixed issue with node version. Build pipeline was failing because the project was built with node 22, but node version 16 was specified in the pipeline.